### PR TITLE
Change version name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-flexberry-account",
-  "version": "=0.1.0-alpha.0",
+  "version": "0.1.0-alpha.0",
   "description": "User account management addon.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
It was impossible to run with `npm link` with fb-designer app. `ember s` resulted in 
`Invalid Version: =0.1.0-alpha.0
TypeError: Invalid Version: =0.1.0-alpha.0`